### PR TITLE
FIX: Generate Types 실행시 백엔드 응답여부 확인 추가

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -2,6 +2,8 @@ import { execSync } from "child_process";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import dotenv from "dotenv";
+import https from "https";
+import http from "http";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,16 +14,60 @@ dotenv.config();
 //백엔드 설정
 const backendUrl = `http://localhost:${process.env.VITE_BACKEND_PORT}` || "http://localhost:8080";
 
+function checkServerStatus(url) {
+  const promise = new Promise((resolve) => {
+    //http 구별
+    const protocol = url.startsWith("https") ? https : http;
+
+    //status 가졍오기
+    const req = protocol.get(url, (res) => {
+      resolve(res.statusCode === 200);
+    });
+
+    //에러
+    req.on("error", () => {
+      resolve(false);
+    });
+
+    //5초이상 응답 없어도 fail
+    req.setTimeout(5000, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+
+  return promise;
+}
+
 //파일 생성 위치
 const outputPath = join(__dirname, "../src/api/autoLoad");
 
 //swagger로 api 가져오기 명령어
 const command = `npx swagger-typescript-api generate --path ${backendUrl}/v2/api-docs --output ${outputPath} --modular --modular-type`;
 
-try {
-  execSync(command, { stdio: "inherit" });
-  console.log("Modular types generated successfully!");
-} catch (error) {
-  console.error("Failed to generate types:", error.message);
-  process.exit(1);
+//타입 생성 시작
+async function generateTypes() {
+  try {
+    //서버 체크
+    console.log("Checking Server...");
+    const isRunning = await checkServerStatus(backendUrl);
+
+    //응답없음
+    if (!isRunning) {
+      console.log("Backend Server is not responding");
+      process.exit(1);
+    }
+
+    console.log("Backend Server is currently running");
+    console.log("Generating Types...");
+
+    //커맨드 실행
+    execSync(command, { studio: "inherit" });
+    console.log("Modular types generated successfully!");
+  } catch (error) {
+    console.error("Failed generate-types process", error.message);
+    process.exit(1);
+  }
 }
+
+generateTypes();


### PR DESCRIPTION
단순 수정사항

swagger-typescript-api 를 scripts/generate-types.js 가 사용할 때 백엔드가 열려있지 않으면 오류를 생성하지 않고 무시