### PR TITLE
Hotfix: 참조와 모듈 해석 방식 오류 수정

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  // "extends": "@vue/tsconfig/tsconfig.dom.json", 오류가 있어서 주석처리
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "src/types/naver-maps.d.ts"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {


### PR DESCRIPTION
## 🔍 관련 이슈
#61 

## ✅ 작업 내역
"extends": "@vue/tsconfig/tsconfig.dom.json" 을 참조하면서 src/api/apiLoad/data-contracts.ts 를 불러오지 못하는 이슈를 수정

저 파일 자체는 node_modules 자체적으로 생성되기 때문에 수정 할 수 없어 일단 참조하지 않는것으로가 옳다고 판단됨

원인은 잘 모르겠으나 상황에 따라 간헐적으로 오류가 발생되어 미친 디버깅 난이도를 가져다줌
