### PR TITLE
[Refactor]모달 컴포넌트 리팩토링

### DIFF
--- a/src/components/common/modal/BaseModal.vue
+++ b/src/components/common/modal/BaseModal.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import DimOverlay from "@/components/layout/DimOverlay.vue";
+import ModalLayout from "@/components/layout/ModalLayout.vue";
+defineProps<{
+  verticalAlign?: "top" | "middle" | "bottom";
+  offset?: number;
+}>();
+</script>
+<template>
+  <DimOverlay @close="$emit('close')">
+    <ModalLayout :verticalAlign="verticalAlign" :offset="offset">
+      <slot></slot>
+    </ModalLayout>
+  </DimOverlay>
+</template>

--- a/src/components/common/modal/ButtonnModal.vue
+++ b/src/components/common/modal/ButtonnModal.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { useToast, ToastType } from "@/utils/useToast";
+import BaseModal from "./BaseModal.vue";
+const props = defineProps<{
+  title: string;
+  hasConfirmBtn?: boolean;
+  handleConfirm?: () =>
+    | Promise<{ success: boolean; message: string }>
+    | { success: boolean; message: string };
+}>();
+
+const { addToast, createToast } = useToast();
+const showToast = (msg: string, type?: ToastType) => {
+  addToast(createToast(msg, type));
+};
+const emit = defineEmits(["close"]);
+async function onConfirm() {
+  if (!props.handleConfirm) {
+    emit("close");
+    return;
+  }
+
+  try {
+    const result = await props.handleConfirm();
+    if (result.success) {
+      showToast(result.message || "성공적으로 처리되었습니다.", "success");
+      emit("close");
+    } else {
+      showToast(result.message || "처리에 실패했습니다.", "error");
+    }
+  } catch (error) {
+    showToast("오류가 발생했습니다.\n" + String(error), "error");
+  }
+}
+</script>
+<template>
+  <BaseModal verticalAlign="middle" @close="$emit('close')">
+    <h2 class="text-xl font-pretendard-bold mb-4">{{ title }}</h2>
+    <!-- 컨텐츠 최대 높이 = 화면 1/2 초과 시 스크롤 생성 -->
+    <div class="max-h-[50vh] overflow-y-auto pt-1 hide-scrollbar">
+      <slot></slot>
+    </div>
+    <div class="flex justify-end gap-2 mt-8">
+      <template v-if="hasConfirmBtn">
+        <button
+          class="rounded-xl w-1/2 cursor-pointer text-white bg-kb-gray-light"
+          @click="$emit('close')"
+        >
+          닫기
+        </button>
+        <button
+          class="rounded-xl w-1/2 py-2 bg-kb-yellow-positive text-white cursor-pointer"
+          @click="onConfirm"
+        >
+          완료
+        </button>
+      </template>
+      <template v-else>
+        <button
+          class="rounded-xl w-full py-2 bg-kb-yellow-positive text-white cursor-pointer"
+          @click="$emit('close')"
+        >
+          확인
+        </button>
+      </template>
+    </div>
+  </BaseModal>
+</template>

--- a/src/components/layout/DimOverlay.vue
+++ b/src/components/layout/DimOverlay.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="fixed inset-0 bg-black/50 z-10" @click.self="$emit('close')">
+    <slot></slot>
+  </div>
+</template>

--- a/src/components/layout/ModalLayout.vue
+++ b/src/components/layout/ModalLayout.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  verticalAlign?: "top" | "middle" | "bottom";
+  offset?: number;
+}>();
+
+// Tailwind가 동적 클래스로는 적용되지 않아 직접 스타일 지정
+const styleValue = computed(() => {
+  const offset = props.offset ?? 32; // 기본 32px
+  switch (props.verticalAlign) {
+    case "top":
+      return { top: `${offset}px` };
+    case "bottom":
+      return { bottom: `${offset}px` };
+    case "middle":
+    default:
+      return { top: "50%", transform: "translateY(-50%)" };
+  }
+});
+</script>
+
+<template>
+  <div class="absolute left-1/2 -translate-x-1/2 w-full px-4 max-w-md" :style="styleValue">
+    <div class="bg-white rounded-xl shadow-lg p-8">
+      <slot></slot>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## 🔍 관련 이슈



## ✅ 작업 내역

/components/common/modal 에 기본 모달과 기존에 사용하던 버튼 모달 작성
기존 코드는 ButtonModal로만 수정하면 지속적으로 사용 가능 - 추후 모든 코드가 변경된다면 기본 ModalForm.vue는 삭제
범용적으로 활용 가능한 BaseModal 생성
/components/layout에 DimOverlay와 ModalLayout 추가
추후 Dim도 재사용 가능. ModalLayout은 모달의 위치를 조정하는 역할
VerticalAlign (top / middle / bottom) 과 offset을 통해 위치 조절 가능해짐

## 📸 스크린샷(선택)

UI 변경 사항이 있다면 캡처해서 보여주세요

## 📎 기타 참고 사항

리뷰어가 참고하면 좋을 내용이 있다면 자유롭게 작성해주세요

