### PR TITLE
Bug: 기본 이미지 변경 적용

### DIFF
--- a/src/pages/mainMenu/MainMenu.vue
+++ b/src/pages/mainMenu/MainMenu.vue
@@ -17,12 +17,15 @@ import movePage from "@/utils/movePage";
 const auth = authStore();
 
 const fileBaseUrl = import.meta.env.VITE_BACKEND_BASE_URL;
-const profileImgUrl = computed(() => {
+const profileImgPath = computed(() => {
+  if (auth.member.createdType === 0) {
+    return logo
+  }
   const path = auth.member.profileImg;
-  if (!path) return logo;
+  if (!path) return defaultProfile;
   return `${fileBaseUrl}${path}`;
 });
-console.log("profileImgUrl: ", profileImgUrl);
+console.log("profileImgPath: ", profileImgPath);
 
 // 로그아웃
 const logout = async () => {
@@ -45,7 +48,7 @@ function openInquiry() {
     <div class="pl-3 pr-8 pt-8 pb-8">
       <div class="mt-[1.5rem] flex items-center justify-center text-center">
         <div class="flex-[1]">
-          <ProfileImage :src="profileImgUrl || defaultProfile" />
+          <ProfileImage :src="profileImgPath" />
         </div>
         <div class="flex-[3]">
           <ProfileInfo

--- a/src/pages/mypage/MyMainPage.vue
+++ b/src/pages/mypage/MyMainPage.vue
@@ -70,13 +70,8 @@ const user = computed(() => ({
   name: auth.member.name ?? "사용자",
   email: auth.member.email ?? "이메일 없음",
   isRegistered: false,
-  imagePath: auth.member.profileImg || defaultProfile,
+  imagePath: auth.member.profileImg ? `${fileBaseUrl}${auth.member.profileImg}` : defaultProfile,
 }));
-const profileImgUrl = computed(() => {
-  const path = auth.member.profileImg;
-  if (!path) return defaultProfile;
-  return `${fileBaseUrl}${path}`;
-});
 
 const isLoading = ref(false);
 const homeData = ref<HomeRegisterResponseDTO | null>(null);
@@ -125,11 +120,11 @@ onMounted(async () => {
     >
       <div class="relative">
         <div class="w-25">
-          <ProfileImage :src="profileImgUrl" />
+          <ProfileImage :src="user.imagePath" />
         </div>
         <button
           class="absolute bottom-0 right-0 cursor-pointer py-1 px-2 bg-kb-ui-08 rounded-full"
-          @click="openModal('profile', { profile: profileImgUrl, name: user.name })"
+          @click="openModal('profile', { profile: user.imagePath, name: user.name })"
         >
           <font-awesome-icon :icon="['fas', 'camera']"></font-awesome-icon>
         </button>


### PR DESCRIPTION
## 🔍 관련 이슈

- closes: #101

## ✅ 작업 내역

- 프로필사진을 **기본 이미지로 변경** 시 **전체 메뉴** 및 **마이페이지** 화면에서도 적용되어야 함

## 📸 스크린샷(선택)
- 변경 요청
<img width="100" alt="image" src="https://github.com/user-attachments/assets/35f1a5a2-1377-49b9-b78b-d99676c5e6d0" />

- 변경 적용된 마이페이지 화면, 전체 메뉴 화면
<img width="100" alt="image" src="https://github.com/user-attachments/assets/ec26fda3-82bf-4d90-bfbf-8e8956cc1e83" />
<img width="100" alt="image" src="https://github.com/user-attachments/assets/fbcb39de-69e9-49b3-9935-e65873eff217" />

## 📎 기타 참고 사항
- 로그인 안 되어 있는 경우
    - 마이페이지 접근 불가
    - 전체 메뉴 화면에서는 logo 및 문구 표시
<img width="100" alt="image" src="https://github.com/user-attachments/assets/7f0caf20-1af9-431f-8276-2ee8f2d4f1a7" />
